### PR TITLE
Correção ortográfica

### DIFF
--- a/docs/4.1/layout/media-object/index.html
+++ b/docs/4.1/layout/media-object/index.html
@@ -299,7 +299,7 @@
               Clearfix
             </a></li><li>
             <a href="/docs/4.1/utilities/close-icon/">
-              Íconde de dispensa
+              Ícone de dispensa
             </a></li><li>
             <a href="/docs/4.1/utilities/colors/">
               Cores


### PR DESCRIPTION
Correção ortográfica no sidebar, no link  "Íconde de dispensa"